### PR TITLE
Respace ranks back to 100, remove Cardboard IV / Plastic III

### DIFF
--- a/truescrub/matchmaking.py
+++ b/truescrub/matchmaking.py
@@ -33,11 +33,11 @@ SKILL_GROUP_NAMES = [
     'Low-Key Dirty',
 ]
 SKILL_GROUPS = ((float('-inf'), SKILL_GROUP_NAMES[0]),) + tuple(
-        (SKILL_GROUP_SPACING * (i + 1), name)
+        (make_elite(SKILL_GROUP_SPACING * (i + 1)), name)
         for i, name in enumerate(SKILL_GROUP_NAMES[1:])
 )
 
-def makeElite(rating):
+def make_elite(rating):
     return 1337 if abs(rating - 1337) < SKILL_GROUP_SPACING / 2 else rating
 
 def skill_group_name(mmr: float) -> str:

--- a/truescrub/matchmaking.py
+++ b/truescrub/matchmaking.py
@@ -14,17 +14,15 @@ MAX_PLAYERS_PER_TEAM = 5
 trueskill.setup(mu=SKILL_MEAN, sigma=SKILL_STDEV, beta=BETA, tau=TAU,
                 draw_probability=0.0)
 
-SKILL_GROUP_SPACING = SKILL_STDEV * 0.3
+SKILL_GROUP_SPACING = SKILL_STDEV * 0.4
 SKILL_GROUP_NAMES = [
     'Scrub',
     'Cardboard I',
     'Cardboard II',
     'Cardboard III',
-    'Cardboard IV',
     'Cardboard Elite',
     'Plastic I',
     'Plastic II',
-    'Plastic III',
     'Plastic Elite',
     'Legendary Wood',
     'Legendary Wood Master',

--- a/truescrub/matchmaking.py
+++ b/truescrub/matchmaking.py
@@ -37,6 +37,8 @@ SKILL_GROUPS = ((float('-inf'), SKILL_GROUP_NAMES[0]),) + tuple(
         for i, name in enumerate(SKILL_GROUP_NAMES[1:])
 )
 
+def makeElite(rating):
+  return 1337 if abs(rating - 1337) < SKILL_GROUP_SPACING / 2 else rating
 
 def skill_group_name(mmr: float) -> str:
     group_ranks = [group[0] for group in SKILL_GROUPS]

--- a/truescrub/matchmaking.py
+++ b/truescrub/matchmaking.py
@@ -38,7 +38,7 @@ SKILL_GROUPS = ((float('-inf'), SKILL_GROUP_NAMES[0]),) + tuple(
 )
 
 def makeElite(rating):
-  return 1337 if abs(rating - 1337) < SKILL_GROUP_SPACING / 2 else rating
+    return 1337 if abs(rating - 1337) < SKILL_GROUP_SPACING / 2 else rating
 
 def skill_group_name(mmr: float) -> str:
     group_ranks = [group[0] for group in SKILL_GROUPS]


### PR DESCRIPTION
This is another way to make greater use of the range, while still keeping the easy to follow 100 / rank.

@trevorc 